### PR TITLE
Units no longer drift after their target is killed

### DIFF
--- a/src/core/unit.gd
+++ b/src/core/unit.gd
@@ -116,6 +116,7 @@ func target_killed(_unit):
     interrupt_attack()
   else:
     target = null
+    velocity = Vector2.ZERO
 
 # triggerd via animation node when the weapon swing happens to deal
 # damage to target


### PR DESCRIPTION
Fixed unit drift by stopping them once their target is killed