### PR TITLE
Fix broken resource references

### DIFF
--- a/graphics/k'inh humans assets/k'inh units/azure cataphract body spritesheet.png.import
+++ b/graphics/k'inh humans assets/k'inh units/azure cataphract body spritesheet.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/azure cataphract body spritesheet.png-04bf6cab29b6dcdc773b63767e5b8c52.stex"
+path="res://.import/azure cataphract body spritesheet.png-e96c323823fdcf2b119d815e2daf9ce7.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/k'inh humans assets/k'inh units/spritesheets/azure cataphract body spritesheet.png"
-dest_files=[ "res://.import/azure cataphract body spritesheet.png-04bf6cab29b6dcdc773b63767e5b8c52.stex" ]
+source_file="res://graphics/k'inh humans assets/k'inh units/azure cataphract body spritesheet.png"
+dest_files=[ "res://.import/azure cataphract body spritesheet.png-e96c323823fdcf2b119d815e2daf9ce7.stex" ]
 
 [params]
 

--- a/graphics/k'inh humans assets/k'inh units/azure cataphract head spritesheet.png.import
+++ b/graphics/k'inh humans assets/k'inh units/azure cataphract head spritesheet.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/azure cataphract head spritesheet.png-77cc89e11a2faf127e8a67752939a448.stex"
+path="res://.import/azure cataphract head spritesheet.png-6c286b27f59cb620cca72686e1873f94.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/k'inh humans assets/k'inh units/spritesheets/azure cataphract head spritesheet.png"
-dest_files=[ "res://.import/azure cataphract head spritesheet.png-77cc89e11a2faf127e8a67752939a448.stex" ]
+source_file="res://graphics/k'inh humans assets/k'inh units/azure cataphract head spritesheet.png"
+dest_files=[ "res://.import/azure cataphract head spritesheet.png-6c286b27f59cb620cca72686e1873f94.stex" ]
 
 [params]
 

--- a/graphics/k'inh humans assets/k'inh units/bamboo spearman body spritesheet.png.import
+++ b/graphics/k'inh humans assets/k'inh units/bamboo spearman body spritesheet.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/bamboo spearman body spritesheet.png-22f52a190b5faa57d9dc893d2f7f9185.stex"
+path="res://.import/bamboo spearman body spritesheet.png-2e61977f0a6f6286cfd30522839188dc.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/k'inh humans assets/k'inh units/spritesheets/bamboo spearman body spritesheet.png"
-dest_files=[ "res://.import/bamboo spearman body spritesheet.png-22f52a190b5faa57d9dc893d2f7f9185.stex" ]
+source_file="res://graphics/k'inh humans assets/k'inh units/bamboo spearman body spritesheet.png"
+dest_files=[ "res://.import/bamboo spearman body spritesheet.png-2e61977f0a6f6286cfd30522839188dc.stex" ]
 
 [params]
 

--- a/graphics/k'inh humans assets/k'inh units/bamboo spearman head spritesheet.png.import
+++ b/graphics/k'inh humans assets/k'inh units/bamboo spearman head spritesheet.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/bamboo spearman head spritesheet.png-8a48ecaff56ebdcce206ee387a46f089.stex"
+path="res://.import/bamboo spearman head spritesheet.png-d7668cc2922efd879fcae3ec551c5884.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/k'inh humans assets/k'inh units/spritesheets/bamboo spearman head spritesheet.png"
-dest_files=[ "res://.import/bamboo spearman head spritesheet.png-8a48ecaff56ebdcce206ee387a46f089.stex" ]
+source_file="res://graphics/k'inh humans assets/k'inh units/bamboo spearman head spritesheet.png"
+dest_files=[ "res://.import/bamboo spearman head spritesheet.png-d7668cc2922efd879fcae3ec551c5884.stex" ]
 
 [params]
 

--- a/graphics/k'inh humans assets/k'inh units/family swordsman body spritesheet.png.import
+++ b/graphics/k'inh humans assets/k'inh units/family swordsman body spritesheet.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/family swordsman body spritesheet.png-f894ee537e40ed78130e506aad1ff1df.stex"
+path="res://.import/family swordsman body spritesheet.png-e77f318b2ea7faf894b7d3f70d7ffbd7.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/k'inh humans assets/k'inh units/spritesheets/family swordsman body spritesheet.png"
-dest_files=[ "res://.import/family swordsman body spritesheet.png-f894ee537e40ed78130e506aad1ff1df.stex" ]
+source_file="res://graphics/k'inh humans assets/k'inh units/family swordsman body spritesheet.png"
+dest_files=[ "res://.import/family swordsman body spritesheet.png-e77f318b2ea7faf894b7d3f70d7ffbd7.stex" ]
 
 [params]
 

--- a/graphics/k'inh humans assets/k'inh units/family swordsman head spritesheet.png.import
+++ b/graphics/k'inh humans assets/k'inh units/family swordsman head spritesheet.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/family swordsman head spritesheet.png-e9d061fb4b1ebdd25748026dff6c3475.stex"
+path="res://.import/family swordsman head spritesheet.png-3ddb82db356871101e5e82b8f49a4049.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/k'inh humans assets/k'inh units/spritesheets/family swordsman head spritesheet.png"
-dest_files=[ "res://.import/family swordsman head spritesheet.png-e9d061fb4b1ebdd25748026dff6c3475.stex" ]
+source_file="res://graphics/k'inh humans assets/k'inh units/family swordsman head spritesheet.png"
+dest_files=[ "res://.import/family swordsman head spritesheet.png-3ddb82db356871101e5e82b8f49a4049.stex" ]
 
 [params]
 

--- a/graphics/k'inh humans assets/k'inh units/jungle archer body spritesheet.png.import
+++ b/graphics/k'inh humans assets/k'inh units/jungle archer body spritesheet.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/jungle archer body spritesheet.png-175207c819365abdb3cc6c8e94c803b5.stex"
+path="res://.import/jungle archer body spritesheet.png-72c090e1ce3af2efc5e18a8d6438359c.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/k'inh humans assets/k'inh units/spritesheets/jungle archer body spritesheet.png"
-dest_files=[ "res://.import/jungle archer body spritesheet.png-175207c819365abdb3cc6c8e94c803b5.stex" ]
+source_file="res://graphics/k'inh humans assets/k'inh units/jungle archer body spritesheet.png"
+dest_files=[ "res://.import/jungle archer body spritesheet.png-72c090e1ce3af2efc5e18a8d6438359c.stex" ]
 
 [params]
 

--- a/graphics/k'inh humans assets/k'inh units/jungle archer head spritesheet.png.import
+++ b/graphics/k'inh humans assets/k'inh units/jungle archer head spritesheet.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/jungle archer head spritesheet.png-db7959d86acedb95508bdd9e73c82322.stex"
+path="res://.import/jungle archer head spritesheet.png-98d22e4d1a8d168456b5ba6a751f0e51.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/k'inh humans assets/k'inh units/spritesheets/jungle archer head spritesheet.png"
-dest_files=[ "res://.import/jungle archer head spritesheet.png-db7959d86acedb95508bdd9e73c82322.stex" ]
+source_file="res://graphics/k'inh humans assets/k'inh units/jungle archer head spritesheet.png"
+dest_files=[ "res://.import/jungle archer head spritesheet.png-98d22e4d1a8d168456b5ba6a751f0e51.stex" ]
 
 [params]
 

--- a/graphics/k'inh humans assets/k'inh units/k'inh human female villager body spritesheet.png.import
+++ b/graphics/k'inh humans assets/k'inh units/k'inh human female villager body spritesheet.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/k'inh human female villager body spritesheet.png-b7c9334f70618945b9948712a47308ad.stex"
+path="res://.import/k'inh human female villager body spritesheet.png-61e1d6d8dc1d75a617d174df92449071.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/k'inh humans assets/k'inh units/spritesheets/k'inh human female villager body spritesheet.png"
-dest_files=[ "res://.import/k'inh human female villager body spritesheet.png-b7c9334f70618945b9948712a47308ad.stex" ]
+source_file="res://graphics/k'inh humans assets/k'inh units/k'inh human female villager body spritesheet.png"
+dest_files=[ "res://.import/k'inh human female villager body spritesheet.png-61e1d6d8dc1d75a617d174df92449071.stex" ]
 
 [params]
 

--- a/graphics/k'inh humans assets/k'inh units/k'inh human female villager head spritesheet.png.import
+++ b/graphics/k'inh humans assets/k'inh units/k'inh human female villager head spritesheet.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/k'inh human female villager head spritesheet.png-171ac81e4a54d0bdf526ca5f36532991.stex"
+path="res://.import/k'inh human female villager head spritesheet.png-f0ebdaba04b23d0733b3fa9e43861d2b.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/k'inh humans assets/k'inh units/spritesheets/k'inh human female villager head spritesheet.png"
-dest_files=[ "res://.import/k'inh human female villager head spritesheet.png-171ac81e4a54d0bdf526ca5f36532991.stex" ]
+source_file="res://graphics/k'inh humans assets/k'inh units/k'inh human female villager head spritesheet.png"
+dest_files=[ "res://.import/k'inh human female villager head spritesheet.png-f0ebdaba04b23d0733b3fa9e43861d2b.stex" ]
 
 [params]
 

--- a/graphics/k'inh humans assets/k'inh units/k'inh human male villager head spritesheet.png.import
+++ b/graphics/k'inh humans assets/k'inh units/k'inh human male villager head spritesheet.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/k'inh human male villager head spritesheet.png-1bfc3ff5091b243a497da3a8ca4f5a72.stex"
+path="res://.import/k'inh human male villager head spritesheet.png-41a3c4a42ae2c840039693984c8a49f1.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/k'inh humans assets/k'inh units/spritesheets/k'inh human male villager head spritesheet.png"
-dest_files=[ "res://.import/k'inh human male villager head spritesheet.png-1bfc3ff5091b243a497da3a8ca4f5a72.stex" ]
+source_file="res://graphics/k'inh humans assets/k'inh units/k'inh human male villager head spritesheet.png"
+dest_files=[ "res://.import/k'inh human male villager head spritesheet.png-41a3c4a42ae2c840039693984c8a49f1.stex" ]
 
 [params]
 

--- a/graphics/k'inh humans assets/k'inh units/lake priestess body spritesheet.png.import
+++ b/graphics/k'inh humans assets/k'inh units/lake priestess body spritesheet.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/lake priestess body spritesheet.png-7d24b1b5210d5ad855b953472d1e3221.stex"
+path="res://.import/lake priestess body spritesheet.png-5effcfcc0a1274562f78a7fc04b87cc5.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/k'inh humans assets/k'inh units/spritesheets/lake priestess body spritesheet.png"
-dest_files=[ "res://.import/lake priestess body spritesheet.png-7d24b1b5210d5ad855b953472d1e3221.stex" ]
+source_file="res://graphics/k'inh humans assets/k'inh units/lake priestess body spritesheet.png"
+dest_files=[ "res://.import/lake priestess body spritesheet.png-5effcfcc0a1274562f78a7fc04b87cc5.stex" ]
 
 [params]
 

--- a/graphics/k'inh humans assets/k'inh units/lake priestess head spritesheet.png.import
+++ b/graphics/k'inh humans assets/k'inh units/lake priestess head spritesheet.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/lake priestess head spritesheet.png-f30ab1f04da8b8c819310364fd6207eb.stex"
+path="res://.import/lake priestess head spritesheet.png-d9ca8a1d437c2fb1ec486240a685ad98.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/k'inh humans assets/k'inh units/spritesheets/lake priestess head spritesheet.png"
-dest_files=[ "res://.import/lake priestess head spritesheet.png-f30ab1f04da8b8c819310364fd6207eb.stex" ]
+source_file="res://graphics/k'inh humans assets/k'inh units/lake priestess head spritesheet.png"
+dest_files=[ "res://.import/lake priestess head spritesheet.png-d9ca8a1d437c2fb1ec486240a685ad98.stex" ]
 
 [params]
 

--- a/graphics/k'inh humans assets/k'inh units/rattan cavalier body.png.import
+++ b/graphics/k'inh humans assets/k'inh units/rattan cavalier body.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/rattan cavalier body.png-40d82f505a2b8bf1604d06a6d0e8b90d.stex"
+path="res://.import/rattan cavalier body.png-1f1a4798265b43f43ac3a08abf53cdf5.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/k'inh humans assets/k'inh units/spritesheets/rattan cavalier body.png"
-dest_files=[ "res://.import/rattan cavalier body.png-40d82f505a2b8bf1604d06a6d0e8b90d.stex" ]
+source_file="res://graphics/k'inh humans assets/k'inh units/rattan cavalier body.png"
+dest_files=[ "res://.import/rattan cavalier body.png-1f1a4798265b43f43ac3a08abf53cdf5.stex" ]
 
 [params]
 

--- a/graphics/k'inh humans assets/k'inh units/rattan cavalier head.png.import
+++ b/graphics/k'inh humans assets/k'inh units/rattan cavalier head.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/rattan cavalier head.png-9b297db2ff8e24b31e985f9108312d17.stex"
+path="res://.import/rattan cavalier head.png-3c03973dd72b113d01cf582d4963ae7f.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/k'inh humans assets/k'inh units/spritesheets/rattan cavalier head.png"
-dest_files=[ "res://.import/rattan cavalier head.png-9b297db2ff8e24b31e985f9108312d17.stex" ]
+source_file="res://graphics/k'inh humans assets/k'inh units/rattan cavalier head.png"
+dest_files=[ "res://.import/rattan cavalier head.png-3c03973dd72b113d01cf582d4963ae7f.stex" ]
 
 [params]
 

--- a/graphics/neutral assets/neutral buildings/land construction site.png.import
+++ b/graphics/neutral assets/neutral buildings/land construction site.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/land construction site.png-abfc36e0540546510e8cfd108f9a16ac.stex"
+path="res://.import/land construction site.png-4d45ea224be4d15acd2abaa9f445dc11.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/neutral buildings/land construction site.png"
-dest_files=[ "res://.import/land construction site.png-abfc36e0540546510e8cfd108f9a16ac.stex" ]
+source_file="res://graphics/neutral assets/neutral buildings/land construction site.png"
+dest_files=[ "res://.import/land construction site.png-4d45ea224be4d15acd2abaa9f445dc11.stex" ]
 
 [params]
 

--- a/graphics/neutral assets/neutral buildings/resource generator crystal growth.png.import
+++ b/graphics/neutral assets/neutral buildings/resource generator crystal growth.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/k'inh human male  villager body spritesheet.png-78e9c663fabaa1f141c3670c2479c8c4.stex"
+path="res://.import/resource generator crystal growth.png-228a4e196fd989a5be41eb06cf53bebb.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/k'inh humans assets/k'inh units/k'inh human male  villager body spritesheet.png"
-dest_files=[ "res://.import/k'inh human male  villager body spritesheet.png-78e9c663fabaa1f141c3670c2479c8c4.stex" ]
+source_file="res://graphics/neutral assets/neutral buildings/resource generator crystal growth.png"
+dest_files=[ "res://.import/resource generator crystal growth.png-228a4e196fd989a5be41eb06cf53bebb.stex" ]
 
 [params]
 

--- a/graphics/neutral assets/neutral buildings/resource generator farm.png.import
+++ b/graphics/neutral assets/neutral buildings/resource generator farm.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/k'inh human male  villager body spritesheet.png-78e9c663fabaa1f141c3670c2479c8c4.stex"
+path="res://.import/resource generator farm.png-49cbfcf1ab88c9d924e9e8c412d750e1.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/k'inh humans assets/k'inh units/k'inh human male  villager body spritesheet.png"
-dest_files=[ "res://.import/k'inh human male  villager body spritesheet.png-78e9c663fabaa1f141c3670c2479c8c4.stex" ]
+source_file="res://graphics/neutral assets/neutral buildings/resource generator farm.png"
+dest_files=[ "res://.import/resource generator farm.png-49cbfcf1ab88c9d924e9e8c412d750e1.stex" ]
 
 [params]
 

--- a/graphics/neutral assets/neutral buildings/resource generator metal mine.png.import
+++ b/graphics/neutral assets/neutral buildings/resource generator metal mine.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/k'inh human male  villager body spritesheet.png-78e9c663fabaa1f141c3670c2479c8c4.stex"
+path="res://.import/resource generator metal mine.png-093e4f8f01c34cf41bc851c7ffdf0e0f.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/k'inh humans assets/k'inh units/k'inh human male  villager body spritesheet.png"
-dest_files=[ "res://.import/k'inh human male  villager body spritesheet.png-78e9c663fabaa1f141c3670c2479c8c4.stex" ]
+source_file="res://graphics/neutral assets/neutral buildings/resource generator metal mine.png"
+dest_files=[ "res://.import/resource generator metal mine.png-093e4f8f01c34cf41bc851c7ffdf0e0f.stex" ]
 
 [params]
 

--- a/graphics/neutral assets/neutral buildings/resource generator warehouse.png.import
+++ b/graphics/neutral assets/neutral buildings/resource generator warehouse.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/k'inh human male  villager body spritesheet.png-78e9c663fabaa1f141c3670c2479c8c4.stex"
+path="res://.import/resource generator warehouse.png-0f3b02a6bff7e58c49d9ef56647078ca.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/k'inh humans assets/k'inh units/k'inh human male  villager body spritesheet.png"
-dest_files=[ "res://.import/k'inh human male  villager body spritesheet.png-78e9c663fabaa1f141c3670c2479c8c4.stex" ]
+source_file="res://graphics/neutral assets/neutral buildings/resource generator warehouse.png"
+dest_files=[ "res://.import/resource generator warehouse.png-0f3b02a6bff7e58c49d9ef56647078ca.stex" ]
 
 [params]
 

--- a/graphics/neutral assets/neutral icons/aggressive icon.png.import
+++ b/graphics/neutral assets/neutral icons/aggressive icon.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/k'inh human male  villager body spritesheet.png-78e9c663fabaa1f141c3670c2479c8c4.stex"
+path="res://.import/aggressive icon.png-9321c4cf490d2bb6b549ca06171f80cd.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/k'inh humans assets/k'inh units/k'inh human male  villager body spritesheet.png"
-dest_files=[ "res://.import/k'inh human male  villager body spritesheet.png-78e9c663fabaa1f141c3670c2479c8c4.stex" ]
+source_file="res://graphics/neutral assets/neutral icons/aggressive icon.png"
+dest_files=[ "res://.import/aggressive icon.png-9321c4cf490d2bb6b549ca06171f80cd.stex" ]
 
 [params]
 

--- a/graphics/neutral assets/neutral icons/defensive icon.png.import
+++ b/graphics/neutral assets/neutral icons/defensive icon.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/k'inh human male  villager body spritesheet.png-78e9c663fabaa1f141c3670c2479c8c4.stex"
+path="res://.import/defensive icon.png-9addca549fc450912dc3ba4b49577012.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/k'inh humans assets/k'inh units/k'inh human male  villager body spritesheet.png"
-dest_files=[ "res://.import/k'inh human male  villager body spritesheet.png-78e9c663fabaa1f141c3670c2479c8c4.stex" ]
+source_file="res://graphics/neutral assets/neutral icons/defensive icon.png"
+dest_files=[ "res://.import/defensive icon.png-9addca549fc450912dc3ba4b49577012.stex" ]
 
 [params]
 

--- a/graphics/neutral assets/neutral icons/passive icon.png.import
+++ b/graphics/neutral assets/neutral icons/passive icon.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/k'inh human male  villager body spritesheet.png-78e9c663fabaa1f141c3670c2479c8c4.stex"
+path="res://.import/passive icon.png-51c06f4b908ee142603d34b4ea0cf610.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/k'inh humans assets/k'inh units/k'inh human male  villager body spritesheet.png"
-dest_files=[ "res://.import/k'inh human male  villager body spritesheet.png-78e9c663fabaa1f141c3670c2479c8c4.stex" ]
+source_file="res://graphics/neutral assets/neutral icons/passive icon.png"
+dest_files=[ "res://.import/passive icon.png-51c06f4b908ee142603d34b4ea0cf610.stex" ]
 
 [params]
 

--- a/graphics/neutral assets/neutral icons/patrol icon.png.import
+++ b/graphics/neutral assets/neutral icons/patrol icon.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/k'inh human male  villager body spritesheet.png-78e9c663fabaa1f141c3670c2479c8c4.stex"
+path="res://.import/patrol icon.png-9a689a219204a797f97c60ecdb1ed8a8.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/k'inh humans assets/k'inh units/k'inh human male  villager body spritesheet.png"
-dest_files=[ "res://.import/k'inh human male  villager body spritesheet.png-78e9c663fabaa1f141c3670c2479c8c4.stex" ]
+source_file="res://graphics/neutral assets/neutral icons/patrol icon.png"
+dest_files=[ "res://.import/patrol icon.png-9a689a219204a797f97c60ecdb1ed8a8.stex" ]
 
 [params]
 

--- a/graphics/neutral assets/neutral units/eastern elephant body spritesheet.png.import
+++ b/graphics/neutral assets/neutral units/eastern elephant body spritesheet.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/eastern elephant body spritesheet.png-7809dc4b201043157148bf00715d19ad.stex"
+path="res://.import/eastern elephant body spritesheet.png-c5bb5fff719f025973e9fa744c381dfa.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/neutral units/eastern elephant body spritesheet.png"
-dest_files=[ "res://.import/eastern elephant body spritesheet.png-7809dc4b201043157148bf00715d19ad.stex" ]
+source_file="res://graphics/neutral assets/neutral units/eastern elephant body spritesheet.png"
+dest_files=[ "res://.import/eastern elephant body spritesheet.png-c5bb5fff719f025973e9fa744c381dfa.stex" ]
 
 [params]
 

--- a/graphics/neutral assets/neutral units/eastern elephant head spritesheet.png.import
+++ b/graphics/neutral assets/neutral units/eastern elephant head spritesheet.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/eastern elephant head spritesheet.png-108c27fedcf24fdb3a28a04e0f085cd9.stex"
+path="res://.import/eastern elephant head spritesheet.png-60a26df96aa188406d4b8bbbbb69fd56.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/neutral units/eastern elephant head spritesheet.png"
-dest_files=[ "res://.import/eastern elephant head spritesheet.png-108c27fedcf24fdb3a28a04e0f085cd9.stex" ]
+source_file="res://graphics/neutral assets/neutral units/eastern elephant head spritesheet.png"
+dest_files=[ "res://.import/eastern elephant head spritesheet.png-60a26df96aa188406d4b8bbbbb69fd56.stex" ]
 
 [params]
 

--- a/graphics/neutral assets/neutral units/eastern elephant saddle spritesheet.png.import
+++ b/graphics/neutral assets/neutral units/eastern elephant saddle spritesheet.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/eastern elephant saddle spritesheet.png-9b3fddec3c34c9a3b2b92c92ba77dbd5.stex"
+path="res://.import/eastern elephant saddle spritesheet.png-4809b3f08514939ed30de8292d31e87b.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/neutral units/eastern elephant saddle spritesheet.png"
-dest_files=[ "res://.import/eastern elephant saddle spritesheet.png-9b3fddec3c34c9a3b2b92c92ba77dbd5.stex" ]
+source_file="res://graphics/neutral assets/neutral units/eastern elephant saddle spritesheet.png"
+dest_files=[ "res://.import/eastern elephant saddle spritesheet.png-4809b3f08514939ed30de8292d31e87b.stex" ]
 
 [params]
 

--- a/graphics/neutral assets/neutral units/horse body spritesheet.png.import
+++ b/graphics/neutral assets/neutral units/horse body spritesheet.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/horse body spritesheet.png-221b23e05c69117df1a4d9826a3bd06f.stex"
+path="res://.import/horse body spritesheet.png-feda57d67cddc8db30cf57df216f49f3.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/neutral units/horse body spritesheet.png"
-dest_files=[ "res://.import/horse body spritesheet.png-221b23e05c69117df1a4d9826a3bd06f.stex" ]
+source_file="res://graphics/neutral assets/neutral units/horse body spritesheet.png"
+dest_files=[ "res://.import/horse body spritesheet.png-feda57d67cddc8db30cf57df216f49f3.stex" ]
 
 [params]
 

--- a/graphics/neutral assets/neutral units/horse head spritesheet.png.import
+++ b/graphics/neutral assets/neutral units/horse head spritesheet.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/horse head spritesheet.png-4c5889db69004043b049fd41b9052c4a.stex"
+path="res://.import/horse head spritesheet.png-b9cf109cfc4ce8b6404020052362c785.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/neutral units/horse head spritesheet.png"
-dest_files=[ "res://.import/horse head spritesheet.png-4c5889db69004043b049fd41b9052c4a.stex" ]
+source_file="res://graphics/neutral assets/neutral units/horse head spritesheet.png"
+dest_files=[ "res://.import/horse head spritesheet.png-b9cf109cfc4ce8b6404020052362c785.stex" ]
 
 [params]
 

--- a/graphics/neutral assets/neutral units/horse light armor spritesheet.png.import
+++ b/graphics/neutral assets/neutral units/horse light armor spritesheet.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/horse light armor spritesheet.png-f4e3cc0f768cebb470bf0351d8eb7053.stex"
+path="res://.import/horse light armor spritesheet.png-038c7b580d138cd65c1109ce19110a8d.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/neutral units/horse light armor spritesheet.png"
-dest_files=[ "res://.import/horse light armor spritesheet.png-f4e3cc0f768cebb470bf0351d8eb7053.stex" ]
+source_file="res://graphics/neutral assets/neutral units/horse light armor spritesheet.png"
+dest_files=[ "res://.import/horse light armor spritesheet.png-038c7b580d138cd65c1109ce19110a8d.stex" ]
 
 [params]
 

--- a/graphics/neutral assets/neutral units/horse saddle spritesheet.png.import
+++ b/graphics/neutral assets/neutral units/horse saddle spritesheet.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/horse saddle spritesheet.png-e18f0fd6bba2c95b98b52cb605070c97.stex"
+path="res://.import/horse saddle spritesheet.png-9a47f19dedab9e22a62c735f5e54bf65.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://graphics/neutral units/horse saddle spritesheet.png"
-dest_files=[ "res://.import/horse saddle spritesheet.png-e18f0fd6bba2c95b98b52cb605070c97.stex" ]
+source_file="res://graphics/neutral assets/neutral units/horse saddle spritesheet.png"
+dest_files=[ "res://.import/horse saddle spritesheet.png-9a47f19dedab9e22a62c735f5e54bf65.stex" ]
 
 [params]
 

--- a/scenes/core/BodyWithAnimation.tscn
+++ b/scenes/core/BodyWithAnimation.tscn
@@ -1046,7 +1046,7 @@ anims/up = SubResource( 11 )
 
 [node name="head" type="Sprite" parent="."]
 material = ExtResource( 6 )
-position = Vector2( -0.37458, -153.349 )
+position = Vector2( -0.37458, -152.55 )
 z_index = 1
 texture = ExtResource( 4 )
 hframes = 4
@@ -1054,7 +1054,7 @@ frame = 1
 
 [node name="body" type="Sprite" parent="."]
 material = ExtResource( 6 )
-position = Vector2( 0, -59.6344 )
+position = Vector2( 0, -58.9279 )
 texture = ExtResource( 2 )
 hframes = 4
 frame = 1

--- a/scenes/core/BodyWithAnimation.tscn
+++ b/scenes/core/BodyWithAnimation.tscn
@@ -1,9 +1,9 @@
 [gd_scene load_steps=46 format=2]
 
 [ext_resource path="res://graphics/k'inh humans assets/k'inh equipment/k'inh sword.png" type="Texture" id=1]
-[ext_resource path="res://graphics/k'inh humans assets/k'inh units/spritesheets/family swordsman body spritesheet.png" type="Texture" id=2]
+[ext_resource path="res://graphics/k'inh humans assets/k'inh units/family swordsman body spritesheet.png" type="Texture" id=2]
 [ext_resource path="res://src/core/BodyWithAnimation.gd" type="Script" id=3]
-[ext_resource path="res://graphics/k'inh humans assets/k'inh units/spritesheets/family swordsman head spritesheet.png" type="Texture" id=4]
+[ext_resource path="res://graphics/k'inh humans assets/k'inh units/family swordsman head spritesheet.png" type="Texture" id=4]
 [ext_resource path="res://graphics/k'inh humans assets/k'inh equipment/rattan shield.png" type="Texture" id=5]
 [ext_resource path="res://assets/shaders/replace_color.tres" type="Material" id=6]
 [ext_resource path="res://graphics/interface/normal selection circle.png" type="Texture" id=7]
@@ -1046,7 +1046,7 @@ anims/up = SubResource( 11 )
 
 [node name="head" type="Sprite" parent="."]
 material = ExtResource( 6 )
-position = Vector2( -0.37458, -151.461 )
+position = Vector2( -0.37458, -153.349 )
 z_index = 1
 texture = ExtResource( 4 )
 hframes = 4
@@ -1054,7 +1054,7 @@ frame = 1
 
 [node name="body" type="Sprite" parent="."]
 material = ExtResource( 6 )
-position = Vector2( 0, -59.417 )
+position = Vector2( 0, -59.6344 )
 texture = ExtResource( 2 )
 hframes = 4
 frame = 1

--- a/scenes/core/building.tscn
+++ b/scenes/core/building.tscn
@@ -1,8 +1,11 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://graphics/k'inh humans assets/k'inh buildings/k'inh human town center tier 1.png" type="Texture" id=1]
 [ext_resource path="res://src/core/building.gd" type="Script" id=2]
 
+[sub_resource type="CapsuleShape2D" id=1]
+radius = 396.173
+height = 110.027
 
 [node name="building" type="StaticBody2D"]
 script = ExtResource( 2 )
@@ -13,3 +16,9 @@ texture = ExtResource( 1 )
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="."]
 polygon = PoolVector2Array( -415.199, -130.508, -412.023, -200.377, 5.6073, -384.579, 404.182, -233.724, 418.474, -149.563, 394.654, -95.573, 243.799, -35.231, -0.0556946, -1.5834, -237.349, -46.3466, -358.032, -78.1055 )
+
+[node name="SelectionArea" type="Area2D" parent="."]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="SelectionArea"]
+position = Vector2( 0, -431.773 )
+shape = SubResource( 1 )

--- a/scenes/core/spearman.tscn
+++ b/scenes/core/spearman.tscn
@@ -1,12 +1,17 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=8 format=2]
 
-[ext_resource path="res://graphics/k'inh humans assets/k'inh units/spritesheets/bamboo spearman head spritesheet.png" type="Texture" id=1]
-[ext_resource path="res://graphics/k'inh humans assets/k'inh units/spritesheets/bamboo spearman body spritesheet.png" type="Texture" id=2]
+[ext_resource path="res://graphics/k'inh humans assets/k'inh units/bamboo spearman head spritesheet.png" type="Texture" id=1]
+[ext_resource path="res://graphics/k'inh humans assets/k'inh units/bamboo spearman body spritesheet.png" type="Texture" id=2]
 [ext_resource path="res://graphics/k'inh humans assets/k'inh equipment/bamboo spear.png" type="Texture" id=3]
 [ext_resource path="res://scenes/core/BodyWithAnimation.tscn" type="PackedScene" id=4]
 [ext_resource path="res://src/core/spearman.gd" type="Script" id=5]
 
+
 [sub_resource type="CircleShape2D" id=1]
+
+[sub_resource type="CapsuleShape2D" id=2]
+radius = 34.9279
+height = 118.355
 
 [node name="Spearman" type="KinematicBody2D"]
 script = ExtResource( 5 )
@@ -22,3 +27,11 @@ shape = SubResource( 1 )
 head_texture = ExtResource( 1 )
 body_texture = ExtResource( 2 )
 right_texture = ExtResource( 3 )
+
+[node name="UnitSelectionArea" type="Area2D" parent="."]
+monitoring = false
+collision_mask = 0
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="UnitSelectionArea"]
+position = Vector2( 0, -96.217 )
+shape = SubResource( 2 )

--- a/scenes/core/spearman.tscn
+++ b/scenes/core/spearman.tscn
@@ -6,7 +6,6 @@
 [ext_resource path="res://scenes/core/BodyWithAnimation.tscn" type="PackedScene" id=4]
 [ext_resource path="res://src/core/spearman.gd" type="Script" id=5]
 
-
 [sub_resource type="CircleShape2D" id=1]
 
 [sub_resource type="CapsuleShape2D" id=2]
@@ -26,6 +25,7 @@ shape = SubResource( 1 )
 [node name="BodyWithAnimation" parent="." instance=ExtResource( 4 )]
 head_texture = ExtResource( 1 )
 body_texture = ExtResource( 2 )
+left_texture = null
 right_texture = ExtResource( 3 )
 
 [node name="UnitSelectionArea" type="Area2D" parent="."]

--- a/scenes/core/swordman.tscn
+++ b/scenes/core/swordman.tscn
@@ -1,31 +1,11 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://scenes/core/BodyWithAnimation.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/core/swordman.gd" type="Script" id=4]
 
 [sub_resource type="CircleShape2D" id=1]
 
-[sub_resource type="StreamTexture" id=2]
-resource_local_to_scene = true
-flags = 4
-load_path = "res://.import/family swordsman head spritesheet.png-492cb977b559d026102239ed74d45d52.stex"
-
-[sub_resource type="StreamTexture" id=3]
-resource_local_to_scene = true
-flags = 4
-load_path = "res://.import/family swordsman body spritesheet.png-b633495bbc1abafbad31dd396a8e0263.stex"
-
-[sub_resource type="StreamTexture" id=4]
-resource_local_to_scene = true
-flags = 4
-load_path = "res://.import/rattan shield.png-528f75c01bd0ea9406b3505579bc5783.stex"
-
-[sub_resource type="StreamTexture" id=5]
-resource_local_to_scene = true
-flags = 4
-load_path = "res://.import/k'inh sword.png-fe35a194ee54545494d65fced73f2348.stex"
-
-[sub_resource type="CapsuleShape2D" id=6]
+[sub_resource type="CapsuleShape2D" id=2]
 radius = 34.9279
 height = 118.355
 
@@ -41,10 +21,6 @@ scale = Vector2( 5.25289, 2.07565 )
 shape = SubResource( 1 )
 
 [node name="BodyWithAnimation" parent="." instance=ExtResource( 1 )]
-head_texture = SubResource( 2 )
-body_texture = SubResource( 3 )
-left_texture = SubResource( 4 )
-right_texture = SubResource( 5 )
 
 [node name="UnitSelectionArea" type="Area2D" parent="."]
 monitoring = false
@@ -52,4 +28,4 @@ collision_mask = 0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="UnitSelectionArea"]
 position = Vector2( 0, -96.217 )
-shape = SubResource( 6 )
+shape = SubResource( 2 )

--- a/scenes/core/swordman.tscn
+++ b/scenes/core/swordman.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://scenes/core/BodyWithAnimation.tscn" type="PackedScene" id=1]
 [ext_resource path="res://src/core/swordman.gd" type="Script" id=4]
@@ -25,6 +25,10 @@ resource_local_to_scene = true
 flags = 4
 load_path = "res://.import/k'inh sword.png-fe35a194ee54545494d65fced73f2348.stex"
 
+[sub_resource type="CapsuleShape2D" id=6]
+radius = 34.9279
+height = 118.355
+
 [node name="swordman" type="KinematicBody2D"]
 script = ExtResource( 4 )
 speed = 200
@@ -41,3 +45,11 @@ head_texture = SubResource( 2 )
 body_texture = SubResource( 3 )
 left_texture = SubResource( 4 )
 right_texture = SubResource( 5 )
+
+[node name="UnitSelectionArea" type="Area2D" parent="."]
+monitoring = false
+collision_mask = 0
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="UnitSelectionArea"]
+position = Vector2( 0, -96.217 )
+shape = SubResource( 6 )

--- a/scenes/core/villagermale.tscn
+++ b/scenes/core/villagermale.tscn
@@ -1,16 +1,24 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=8 format=2]
 
-[ext_resource path="res://graphics/k'inh humans assets/k'inh units/spritesheets/k'inh human male villager head spritesheet.png" type="Texture" id=1]
+[ext_resource path="res://graphics/k'inh humans assets/k'inh units/k'inh human male villager head spritesheet.png" type="Texture" id=1]
 [ext_resource path="res://src/core/villagermale.gd" type="Script" id=2]
-[ext_resource path="res://graphics/k'inh humans assets/k'inh units/spritesheets/k'inh human male  villager body spritesheet.png" type="Texture" id=3]
+[ext_resource path="res://graphics/k'inh humans assets/k'inh units/k'inh human male  villager body spritesheet.png" type="Texture" id=3]
 [ext_resource path="res://scenes/core/BodyWithAnimation.tscn" type="PackedScene" id=4]
 [ext_resource path="res://graphics/k'inh humans assets/k'inh equipment/builder's hammer.png" type="Texture" id=5]
 
+<<<<<<< Updated upstream
 
 
+
+=======
+>>>>>>> Stashed changes
 [sub_resource type="CapsuleShape2D" id=1]
 radius = 25.5323
 height = 37.9793
+
+[sub_resource type="CapsuleShape2D" id=2]
+radius = 34.9279
+height = 118.355
 
 [node name="peon" type="KinematicBody2D"]
 script = ExtResource( 2 )
@@ -26,3 +34,11 @@ head_texture = ExtResource( 1 )
 body_texture = ExtResource( 3 )
 left_texture = null
 right_texture = ExtResource( 5 )
+
+[node name="UnitSelectionArea" type="Area2D" parent="."]
+monitoring = false
+collision_mask = 0
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="UnitSelectionArea"]
+position = Vector2( 0, -96.217 )
+shape = SubResource( 2 )

--- a/src/core/map.gd
+++ b/src/core/map.gd
@@ -39,18 +39,9 @@ func _process(_delta):
     
   # Mouse1 released, check what is selected
   if Input.is_action_just_released("select"):
-    var new_selection = []
-    if selection_box.is_valid():
-      var result = selection_box.get_selected_units(team)
-      for item in result:
-        new_selection.append(item["collider"])
-    else:
-      var result = get_unit_or_position_under_cursor(false)
-      if typeof(result) == TYPE_VECTOR2:
-        gui.reset_actions()
-      else:
-        new_selection = [result]
+    var new_selection = selection_box.get_selected_units(team)
     selection_box.reset()
+    gui.reset_actions()
     set_selected_units(new_selection)
     if selected_units.size() > 0:
       gui.setup_actions(selected_units[0].get_actions())
@@ -78,7 +69,7 @@ func get_unit_or_position_under_cursor(any_team : bool):
 
 # If gui reports action to perfrom, tell selected unit to perfrom action
 func receive_perform_action(action_name):
-  for unit in selected_units:
+  for unit in get_selected_units():
     unit.perform_action(action_name, $YSort)
 
 # Helper function to update unit display

--- a/src/core/unit.gd
+++ b/src/core/unit.gd
@@ -28,6 +28,7 @@ var health = 3
 var state = NORMAL
 var type_name = "Unit"
 onready var animated_body : BodyWithAnimation = $BodyWithAnimation
+onready var selection_area : Area2D = $UnitSelectionArea
 
 func reset():
   health = max_health
@@ -43,6 +44,9 @@ func set_team(team_no):
   set_collision_layer(0x0)
   set_collision_layer_bit(team_no, true)
   set_collision_mask(0xff)
+  selection_area.set_collision_layer(0x0)
+  selection_area.set_collision_layer_bit(team_no, true)
+  selection_area.set_collision_mask(0xff)
   $BodyWithAnimation.set_team_colors(team_no)
 
 func _ready():
@@ -172,6 +176,7 @@ func get_actions():
 
 func perform_action(action, _world):
   if action == "Destroy":
+    velocity = Vector2.ZERO
     state = DEAD
     emit_signal("died", self)
     play_animation("death")


### PR DESCRIPTION
Fixed some resource references for unit sprites.
Hopefully fixed the crash when destroying selected units/buildings.
Units stop in place when destroyed.